### PR TITLE
Non-breaking bugfix for missing tracklist stars 

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -275,9 +275,9 @@ function updateTracklist() {
         const tracks = tracklist.getElementsByClassName("main-trackList-trackListRow");
         for (const track of tracks) {
             const getHeart = () => {
-                return track.getElementsByClassName("main-addButton-button")[0];
+                return track.getElementsByClassName("main-addButton-button")[0] ?? track.querySelector(".main-trackList-rowHeartButton");
             };
-            const heart = track.getElementsByClassName("main-addButton-button")[0];
+            const heart = track.getElementsByClassName("main-addButton-button")[0] ?? track.querySelector(".main-trackList-rowHeartButton");
             const hasStars = track.getElementsByClassName("stars").length > 0;
             const trackUri = getTracklistTrackUri(track);
             const isTrack = trackUri.includes("track");


### PR DESCRIPTION
Stars seemingly weren't being added to tracklists (no `.main-addButton-button` element[s] found, so I just added a querySelector call for `.main-trackList-rowHeartButton` in case the former selector doesn't find anything).

Might just be me, or maybe broken due to a Spotify update (they do love to change the class names, and I did update recently).

For reference:
Spotify for Windows (64 bit)
1.2.17.834.g26ee1129
Spicetify v2.22.1

It's backwards compatible anyway, nothing removed, just added a fallback.