### PR TITLE
Fix for stars no longer appearing in tracklists.

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -61,12 +61,12 @@ function trackUriToTrackId(trackUri) {
 function getTracklistTrackUri(tracklistElement) {
     let values = Object.values(tracklistElement);
     if (!values) return null;
-
+    const searchFrom = values[0]?.pendingProps?.children[0]?.props?.children;
     return (
-        values[0]?.pendingProps?.children[0]?.props?.children?.props?.uri ||
-        values[0]?.pendingProps?.children[0]?.props?.children?.props?.children?.props?.uri ||
-        values[0]?.pendingProps?.children[0]?.props?.children?.props?.children?.props?.children?.props?.uri ||
-        values[0]?.pendingProps?.children[0]?.props?.children[0]?.props?.uri
+        searchFrom?.props?.uri ||
+        searchFrom?.props?.children?.props?.uri ||
+        searchFrom?.props?.children?.props?.children?.props?.uri ||
+        searchFrom[0]?.props?.uri
     );
 }
 
@@ -275,9 +275,9 @@ function updateTracklist() {
         const tracks = tracklist.getElementsByClassName("main-trackList-trackListRow");
         for (const track of tracks) {
             const getHeart = () => {
-                return track.getElementsByClassName("main-addButton-button")[0] ?? track.querySelector(".main-trackList-rowHeartButton");
+                return track.getElementsByClassName("main-addButton-button")[0] ?? track.querySelector(".main-trackList-rowHeartButton") ?? track.querySelector("button[class*='buttonTertiary-iconOnly']") ?? track.querySelector("button[aria-label='Add to playlist']");
             };
-            const heart = track.getElementsByClassName("main-addButton-button")[0] ?? track.querySelector(".main-trackList-rowHeartButton");
+            const heart = getHeart();
             const hasStars = track.getElementsByClassName("stars").length > 0;
             const trackUri = getTracklistTrackUri(track);
             const isTrack = trackUri.includes("track");


### PR DESCRIPTION
Looks like the Heart/Like button selector changed.
Not sure if this is an issue for everyone, or because of my particular setup so I've left the "old" selectors in so it remains backwards compatible.


My Spotify/Spicetify info in case it's relevant:
> Spotify for Windows (64 bit)
> 1.2.19.941.gbf202593
> Spicetify v2.23.0
> Theme: Matte / matte
> Extensions: mm.testbench.js, queuePanel.js, star-ratings.js, playNextWrapper.js, volumePercentageWrapper.js, spotifyBackup.js, css-editor.js, copyPlaylistInfo.js, tracksToEdges.js, seekonscroll.js, utilities.js, imaged-folders.js, sortByPlayCount.js, find-duplicates.js, listPlaylistsWithSong.js, fullAlbumDate.js
> Custom apps: new-releases, lyrics-plus, marketplace, ncs-visualizer